### PR TITLE
Update Gitea Helm chart and deployment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ local$ make
 
 ```bash
 local$ make demo
-local$ cd terraform; echo "`terraform output loadbalancer-ip` www.gitea.local"
+local$ cd terraform; echo "$(terraform output -raw loadbalancer-ip) www.gitea.local"
 local$ # add above command output to /etc/hosts
 ```
 
-Now browse to http://www.gitea.local and finish the Gitea installation.
+Now browse to http://www.gitea.local and log in with user `gitea_admin` and password `gitea_admin`.
 
 ## summary
 

--- a/ansible/demo/99-setup-microk8s-gitea.yml
+++ b/ansible/demo/99-setup-microk8s-gitea.yml
@@ -6,8 +6,8 @@
   tasks:
 
       # helm repo command is idempotent
-      - name: "add k8s-land helm repo"
-        command: /snap/bin/helm repo add k8s-land https://charts.k8s.land
+      - name: "add gitea-charts helm repo"
+        command: /snap/bin/helm repo add gitea-charts https://dl.gitea.com/charts/
         changed_when: false
 
       - name: "upload values-gitea.yaml into /root"
@@ -17,7 +17,7 @@
             owner: root
             group: root
             mode: '0644'
-            checksum: 3ca56ef72d756c8a34480a4895f1d23fab5569b6
+            checksum: b91bf7b00831c3539845b1085fbc1e471d4cd623
 
       - name: "check for gitea helm release"
         command: /snap/bin/helm status gitea
@@ -28,6 +28,6 @@
 
       - name: "install gitea helm chart"
         command: >
-            /snap/bin/helm install gitea k8s-land/gitea
+            /snap/bin/helm install gitea gitea-charts/gitea
             -f /root/values-gitea.yaml
         when: gitea_status.rc != 0

--- a/ansible/files/demo/values-gitea.yaml
+++ b/ansible/files/demo/values-gitea.yaml
@@ -1,219 +1,84 @@
-## Gitea image
-## ref: https://hub.docker.com/r/gitea/gitea/tags/
-##
+# Values for gitea-charts/gitea
 
-tags:
-  mariadb: true
-
-images:
+image:
   registry: docker.io
-  gitea: "gitea/gitea:1.11.5"
-  memcached: "memcached:1.5.19-alpine"
-  pullPolicy: IfNotPresent
-  ## Optionally specify an array of imagePullSecrets.
-  ## Secrets must be manually created in the namespace.
-  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
-  ##
-  # pullSecrets:
-  #   - myRegistryKeySecretName
+  repository: gitea/gitea
+  tag: latest
+  rootless: false
 
-## Cache settings for memcache
-memcached:
-  maxItemMemory: 64
-  verbosity: v
-  extendedOptions: modern
-
-## Configure the ingress resource that allows you to access the
-## Gitea installation. Set up the URL
-## ref: http://kubernetes.io/docs/user-guide/ingress/
-##
 ingress:
-  ## Set to true to enable ingress record generation
   enabled: true
+  className: public
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+  hosts:
+    - host: www.gitea.local
+      paths:
+        - path: /
+          pathType: Prefix
 
-  ## Set this to true in order to add the corresponding annotations for cert-manager
-  certManager: false
-
-  ## When the ingress is enabled, a host pointing to this will be created
-  hostname: www.gitea.local
-
-  ## Ingress annotations done as key:value pairs
-  ## For a full list of possible ingress annotations, please see
-  ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
-  ##
-  ## If tls is set to true, annotation ingress.kubernetes.io/secure-backends: "true" will automatically be set
-  ## If certManager is set to true, annotation kubernetes.io/tls-acme: "true" will automatically be set
-  annotations: {}
-  #  certmanager.k8s.io/cluster-issuer: letsencrypt-prod
-  #  kubernetes.io/ingress.class: nginx
-
-  ## The list of additional hostnames to be covered with this ingress record.
-  ## Most likely the hostname above will be enough, but in the event more hosts are needed, this is an array
-  # hosts:
-  # - name: gitea.local
-  #   path: /
-
-  ## The tls configuration for the ingress
-  ## see: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
-  ## Uncomment below to enable tls / https for let's encrypt / cert-manager
-  # tls:
-  #  - hosts:
-  #    - gitea.local
-  #    secretName: gitea.tls
-
-  secrets:
-  ## If you're providing your own certificates, please use this to add the certificates as secrets
-  ## key and certificate should start with -----BEGIN CERTIFICATE----- or
-  ## -----BEGIN RSA PRIVATE KEY-----
-  ##
-  ## name should line up with a tlsSecret set further up
-  ## If you're using cert-manager, this is unneeded, as it will create the secret for you if it is not set
-  ##
-  ## It is also possible to create and manage the certificates outside of this helm chart
-  ## Please see README.md for more information
-  # - name: gitea.local-tls
-  #   key:
-  #   certificate:
-  #
-
-## This chart defaults to using an ingress for http, but change to LoadBalancer if using you cluster supports it
 service:
-
-  ## This can stay as ClusterIP as (by default) we use ingress
   http:
-    serviceType: ClusterIP
+    type: ClusterIP
+    clusterIP: ""
     port: 3000
-    ## Make the external port available
-    # externalPort: 8280
-    # externalHost: gitea.local
-
-  ## SSH is commonly on port 22.. however.. you most likely already have port 22 being used by your node.
-  ## so we use port 8022.
   ssh:
-    serviceType: NodePort
+    type: NodePort
     port: 22
     nodePort: 30222
-    ## If serving on a different external port used for determining the ssh url in the gui
-    externalPort: 30222
-    externalHost: ssh.gitea.local
-    externalIPs: []
 
-## Configure resource requests and limits
-## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-##
-resources:
-  gitea:
-    requests:
-      memory: 500Mi
-      cpu: 1000m
-    limits:
-      memory: 2Gi
-      cpu: 1
-  memcached:
-    requests:
-      memory: 64Mi
-      cpu: 50m
-
-## Enable persistence using Persistent Volume Claims
-## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-## ref:
-##
 persistence:
   enabled: true
-  # existingGiteaClaim: gitea-gitea
-  giteaSize: 10Gi
-  # storageClass: glusterfs
-  accessMode: ReadWriteMany
-  ## addtional annotations for PVCs. Uncommenting will prevent the PVC from being deleted.
-  annotations:
-    "helm.sh/resource-policy": keep
+  size: 10Gi
+  accessModes:
+    - ReadWriteMany
+  claimName: gitea-shared-storage
 
-## if you want to mount a volume directly without using a storageClass or pvcs
-#  directGiteaVolumeMount:
-#    glusterfs:
-#      endpoints: "192.168.1.1 192.168.1.2 192.168.1.3"
-#      path: giteaData
-#  directPostgresVolumeMount:
-#    glusterfs:
-#      endpoints: "192.168.1.1 192.168.1.2 192.168.1.3"
-#      path: giteaPostgresData
+gitea:
+  admin:
+    existingSecret: ""
+    username: gitea_admin
+    password: gitea_admin
+    email: "gitea@local.domain"
+  config:
+    APP_NAME: "Gitea"
+    server:
+      DOMAIN: www.gitea.local
+      ROOT_URL: "http://www.gitea.local/"
+      SSH_PORT: 30222
+      SSH_LISTEN_PORT: 2222
+    service:
+      REQUIRE_SIGNIN_VIEW: false
+      DISABLE_REGISTRATION: false
+    openid:
+      ENABLE_OPENID_SIGNIN: true
+    security:
+      INSTALL_LOCK: false
 
+postgresql-ha:
+  enabled: false
 
-##
-## MariaDB chart configuration
-##
-## https://github.com/helm/charts/blob/master/stable/mariadb/values.yaml
-##
-mariadb:
-  ## Whether to deploy a mariadb server to satisfy the applications database requirements. To use an external database set this to false and configure the externalDatabase parameters
+postgresql:
   enabled: true
-  ## Disable MariaDB replication
-  replication:
-    enabled: false
-  volumePermissions:
-      enabled: true
-
-  ## Create a database and a database user
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#creating-a-database-user-on-first-run
-  ##
-  db:
-    name: gitea
-    user: gitea
-    ## If the password is not specified, mariadb will generates a random password
-    ##
-    # password: ThisIsMySuperSecretPassword
-
-  ## MariaDB admin password
-  ## ref: https://github.com/bitnami/bitnami-docker-mariadb/blob/master/README.md#setting-the-root-password-on-first-run
-  ##
-  rootUser:
-    # password: ThisIsMySuperSecretPassword
-
-  ## Enable persistence using Persistent Volume Claims
-  ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
-  ##
-  master:
+  global:
+    postgresql:
+      auth:
+        username: gitea
+        password: gitea
+        database: gitea
+  primary:
     persistence:
-      enabled: true
-      ## mariadb data Persistent Volume Storage Class
-      ## If defined, storageClassName: <storageClass>
-      ## If set to "-", storageClassName: "", which disables dynamic provisioning
-      ## If undefined (the default) or set to null, no storageClassName spec is
-      ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
-      ##   GKE, AWS & OpenStack)
-      ##
-      # storageClass: "-"
-      accessMode: ReadWriteOnce
-      size: 8Gi
+      size: 10Gi
 
-## Connect to an external database instead
-# externalDB:
-#   dbUser: "postgres"
-#   dbPassword: "<MY_PASSWORD>"
-#   dbHost: "service-name.namespace.svc.cluster.local" # or some external host
-#   dbPort: "5432"
-#   dbDatabase: "gitea"
+valkey-cluster:
+  enabled: false
 
+valkey:
+  enabled: true
+  architecture: standalone
+  auth:
+    enabled: true
+    password: gitea
 
-## Actual Gitea configuration (modified the default .ini file for Gitea)
-## This will skip the initial installation screen. You must have a secretKey already defined
-## and disableInstaller set to True
-config:
-  ##  secretKey: ThisIsMySuperSecretKeyThatsUsedInterally
-  disableInstaller: false
-  offlineMode: false
-  requireSignin: false
-  disableRegistration: false
-  openidSignin: true
-
-## Common helm annotations
-## Node labels and tolerations for pod assignment
-## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
-## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#taints-and-tolerations-beta-feature
-nodeSelector: {}
-tolerations: []
-affinity: {}
-
-## Annotations for the deployment and nodes.
-deploymentAnnotations: {}
-podAnnotations: {}
+mariadb:
+  enabled: false


### PR DESCRIPTION
- Switch to official `gitea-charts/gitea` Helm repository and chart.
- Complete rewrite of values-gitea.yaml to match new chart version requirements:
  - Migrate backend to PostgreSQL and Valkey (Redis replacement).
  - Configure Ingress with `public` class and rewrite annotations.
  - Set default admin credentials (`gitea_admin`).
- Fix `terraform output` command in README.md to use raw output format.
- Update README.md with new login instructions and credentials.