### PR TITLE
chore: modernize repo dependencies and ansible tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,12 @@ terraform/.terraform.lock.hcl
 
 # Ansible inventory
 ansible/inventory/hosts
+
+# Editors
+.vscode
+.idea
+*.swp
+*.swo
+
+# OS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # k8s-dev-cluster-hcloud
 
 Build a minimal *highly available (HA) Kubernetes cluster* with zero effort in less
-than 10 minutes in Hetzner Cloud aka hcloud with Terraform >= 0.13, Ansible and MicroK8s
+than 10 minutes in Hetzner Cloud aka hcloud with Terraform >= 1.5, Ansible and MicroK8s
 for development.
 
 > New in 1.19, high availability is automatically enabled on MicroK8s for clusters

--- a/ansible/01-setup-microk8s-snap.yml
+++ b/ansible/01-setup-microk8s-snap.yml
@@ -4,52 +4,50 @@
   gather_facts: "no"
 
   tasks:
+    - name: "update packages to the latest"
+      apt:
+        upgrade: dist
+        update_cache: "yes"
 
-      - name: "update packages to the latest"
-        apt:
-            upgrade: dist
-            update_cache: "yes"
+    - name: "install snapd package"
+      apt:
+        package: snapd
+        state: present
 
-      - name: "install snapd package"
-        apt:
-            package: snapd
-            state: present
-
-      - name: "install latest stable microk8s snap"
-        snap:
-            name: microk8s
-            channel: latest
-            classic: "yes"
-            state: present
-        notify:
-            - enable snapd
-            - start snapd
-            - enable microk8s addons
-            - reboot
+    - name: "install microk8s snap"
+      snap:
+        name: microk8s
+        channel: 1.30/stable
+        classic: "yes"
+        state: present
+      notify:
+        - enable snapd
+        - start snapd
+        - enable microk8s addons
+        - reboot
 
   handlers:
+    - name: "enable snapd"
+      service:
+        name: snapd
+        enabled: "yes"
 
-      - name: "enable snapd"
-        service:
-            name: snapd
-            enabled: "yes"
+    - name: "start snapd"
+      service:
+        name: snapd
+        state: started
 
-      - name: "start snapd"
-        service:
-            name: snapd
-            state: started
+    - name: "enable microk8s addons"
+      command: /snap/bin/microk8s.enable "{{ item }}"
+      loop:
+        - dns
+        - helm3
+        - ingress
+        - storage
+      environment:
+        LC_ALL: "C.UTF-8"
+        LANG: "C.UTF-8"
 
-      - name: "enable microk8s addons"
-        command: /snap/bin/microk8s.enable "{{ item }}"
-        loop:
-            - dns
-            - helm3
-            - ingress
-            - storage
-        environment:
-            LC_ALL: "C.UTF-8"
-            LANG: "C.UTF-8"
-
-      - name: "reboot"
-        reboot:
-            reboot_timeout: 120
+    - name: "reboot"
+      reboot:
+        reboot_timeout: 120

--- a/ansible/04-setup-microk8s-metallb.yml
+++ b/ansible/04-setup-microk8s-metallb.yml
@@ -4,17 +4,14 @@
   gather_facts: "no"
 
   tasks:
+    - name: "check metallb addon"
+      command: /snap/bin/microk8s.status -a metallb
+      register: metallb_status
+      changed_when: false
 
-      - name: "check metallb addon"
-        command: /snap/bin/microk8s.status -a metallb
-        register: metallb_status
-        changed_when: false
-
-      - name: "enable metallb addon"
-        shell: >
-            echo "{{ loadbalancer_ip }}-{{ loadbalancer_ip }}" |
-            /snap/bin/microk8s.enable metallb
-        environment:
-            LC_ALL: "C.UTF-8"
-            LANG: "C.UTF-8"
-        when: metallb_status.stdout == "disabled"
+    - name: "enable metallb addon"
+      command: /snap/bin/microk8s.enable metallb:{{ loadbalancer_ip }}-{{ loadbalancer_ip }}
+      environment:
+        LC_ALL: "C.UTF-8"
+        LANG: "C.UTF-8"
+      when: metallb_status.stdout == "disabled"

--- a/ansible/demo/99-setup-microk8s-gitea.yml
+++ b/ansible/demo/99-setup-microk8s-gitea.yml
@@ -4,30 +4,30 @@
   gather_facts: "no"
 
   tasks:
+    # helm repo command is idempotent
+    - name: "add gitea-charts helm repo"
+      command: /snap/bin/helm repo add gitea-charts https://dl.gitea.com/charts/
+      changed_when: false
 
-      # helm repo command is idempotent
-      - name: "add gitea-charts helm repo"
-        command: /snap/bin/helm repo add gitea-charts https://dl.gitea.com/charts/
-        changed_when: false
+    - name: "upload values-gitea.yaml into /root"
+      copy:
+        src: ../files/demo/values-gitea.yaml
+        dest: /root/values-gitea.yaml
+        owner: root
+        group: root
+        mode: "0644"
+        checksum: b91bf7b00831c3539845b1085fbc1e471d4cd623
 
-      - name: "upload values-gitea.yaml into /root"
-        copy:
-            src: ../files/demo/values-gitea.yaml
-            dest: /root/values-gitea.yaml
-            owner: root
-            group: root
-            mode: '0644'
-            checksum: b91bf7b00831c3539845b1085fbc1e471d4cd623
+    - name: "check for gitea helm release"
+      command: /snap/bin/helm status gitea
+      register: gitea_status
+      failed_when: false
+      changed_when: false
+      ignore_errors: "true"
 
-      - name: "check for gitea helm release"
-        command: /snap/bin/helm status gitea
-        register: gitea_status
-        failed_when: false
-        changed_when: false
-        ignore_errors: "true"
-
-      - name: "install gitea helm chart"
-        command: >
-            /snap/bin/helm install gitea gitea-charts/gitea
-            -f /root/values-gitea.yaml
-        when: gitea_status.rc != 0
+    - name: "install gitea helm chart"
+      command: >
+        /snap/bin/helm upgrade --install gitea gitea-charts/gitea
+        -f /root/values-gitea.yaml
+        --namespace default
+      when: gitea_status.rc != 0

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.13"
+  required_version = "~> 1.5"
 }


### PR DESCRIPTION
- Update Terraform required version to ~> 1.5 in versions.tf and README.
- Pin MicroK8s snap channel to 1.30/stable for improved stability.
- Update MetalLB enable command to use modern syntax (fix legacy pipe usage).
- Use `helm upgrade --install` for Gitea deployment for better idempotency.
- Update .gitignore with common editor and OS artifacts.